### PR TITLE
Send Content-Type through to presign requests.

### DIFF
--- a/lib/components/fields/multi-upload-field/index.js
+++ b/lib/components/fields/multi-upload-field/index.js
@@ -1,3 +1,5 @@
+var _slicedToArray = function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i["return"]) _i["return"](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError("Invalid attempt to destructure non-iterable instance"); } }; }();
+
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 var _jsxFileName = "src/components/fields/multi-upload-field/index.js";
@@ -653,7 +655,7 @@ var MultiUploadField = function (_React$Component2) {
         index: index,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 1053
+          lineNumber: 1057
         },
         __self: this
       });
@@ -751,7 +753,7 @@ var MultiUploadField = function (_React$Component2) {
           "data-field-type": multiple ? "multi-upload-field" : "upload-field",
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 1189
+            lineNumber: 1193
           },
           __self: this
         },
@@ -760,7 +762,7 @@ var MultiUploadField = function (_React$Component2) {
           {
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 1194
+              lineNumber: 1198
             },
             __self: this
           },
@@ -769,13 +771,13 @@ var MultiUploadField = function (_React$Component2) {
             {
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1195
+                lineNumber: 1199
               },
               __self: this
             },
             React.createElement(FieldHeader, { hint: hint, id: name, label: label, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1196
+                lineNumber: 1200
               },
               __self: this
             })
@@ -792,7 +794,7 @@ var MultiUploadField = function (_React$Component2) {
               disableClick: files.length > 0,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 1204
+                lineNumber: 1208
               },
               __self: this
             },
@@ -800,7 +802,7 @@ var MultiUploadField = function (_React$Component2) {
           ),
           hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 1213
+              lineNumber: 1217
             },
             __self: this
           }) : null
@@ -1056,7 +1058,15 @@ var _initialiseProps = function _initialiseProps() {
     // Push into uploadQueue
     _this7.addToUploadQueue(fileObject.uid);
 
-    _this7.uploader.presign.apply(_this7, _this7.uploaderPresignArgs).then(function (presignResponse) {
+    var _uploaderPresignArgs = _slicedToArray(_this7.uploaderPresignArgs, 3),
+        path = _uploaderPresignArgs[0],
+        csrfToken = _uploaderPresignArgs[1],
+        params = _uploaderPresignArgs[2];
+
+    params = Object.assign({}, params);
+    params.content_type = fileObject.type;
+
+    _this7.uploader.presign.apply(_this7, [path, csrfToken, params]).then(function (presignResponse) {
       // assign the return 'url' to upload_url so
       // we can create paths to the file
       upload_url = presignResponse.url;
@@ -1241,7 +1251,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { key: index, className: styles.validationMessage, __source: {
           fileName: _jsxFileName,
-          lineNumber: 846
+          lineNumber: 850
         },
         __self: _this7
       },
@@ -1250,7 +1260,7 @@ var _initialiseProps = function _initialiseProps() {
         "button",
         { className: styles.remove, __source: {
             fileName: _jsxFileName,
-            lineNumber: 848
+            lineNumber: 852
           },
           __self: _this7
         },
@@ -1258,7 +1268,7 @@ var _initialiseProps = function _initialiseProps() {
           "span",
           { className: styles.removeText, __source: {
               fileName: _jsxFileName,
-              lineNumber: 849
+              lineNumber: 853
             },
             __self: _this7
           },
@@ -1272,7 +1282,7 @@ var _initialiseProps = function _initialiseProps() {
             "data-key": index,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 850
+              lineNumber: 854
             },
             __self: _this7
           },
@@ -1287,7 +1297,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.validationMessages, __source: {
           fileName: _jsxFileName,
-          lineNumber: 871
+          lineNumber: 875
         },
         __self: _this7
       },
@@ -1305,7 +1315,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { key: index, className: styles.validationMessage, __source: {
           fileName: _jsxFileName,
-          lineNumber: 890
+          lineNumber: 894
         },
         __self: _this7
       },
@@ -1314,7 +1324,7 @@ var _initialiseProps = function _initialiseProps() {
         {
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 891
+            lineNumber: 895
           },
           __self: _this7
         },
@@ -1326,7 +1336,7 @@ var _initialiseProps = function _initialiseProps() {
         "button",
         { className: styles.remove, __source: {
             fileName: _jsxFileName,
-            lineNumber: 892
+            lineNumber: 896
           },
           __self: _this7
         },
@@ -1334,7 +1344,7 @@ var _initialiseProps = function _initialiseProps() {
           "span",
           { className: styles.removeText, __source: {
               fileName: _jsxFileName,
-              lineNumber: 893
+              lineNumber: 897
             },
             __self: _this7
           },
@@ -1348,7 +1358,7 @@ var _initialiseProps = function _initialiseProps() {
             "data-key": index,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 894
+              lineNumber: 898
             },
             __self: _this7
           },
@@ -1363,7 +1373,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.validationMessages, __source: {
           fileName: _jsxFileName,
-          lineNumber: 915
+          lineNumber: 919
         },
         __self: _this7
       },
@@ -1376,7 +1386,7 @@ var _initialiseProps = function _initialiseProps() {
 
     return React.createElement("img", { src: thumbnail_url, alt: file_name, __source: {
         fileName: _jsxFileName,
-        lineNumber: 932
+        lineNumber: 936
       },
       __self: _this7
     });
@@ -1395,7 +1405,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: wrapperClassNames, __source: {
           fileName: _jsxFileName,
-          lineNumber: 959
+          lineNumber: 963
         },
         __self: _this7
       },
@@ -1403,7 +1413,7 @@ var _initialiseProps = function _initialiseProps() {
         "div",
         { className: styles.listItem__img, __source: {
             fileName: _jsxFileName,
-            lineNumber: 960
+            lineNumber: 964
           },
           __self: _this7
         },
@@ -1413,7 +1423,7 @@ var _initialiseProps = function _initialiseProps() {
         "div",
         { className: titleClassNames, __source: {
             fileName: _jsxFileName,
-            lineNumber: 961
+            lineNumber: 965
           },
           __self: _this7
         },
@@ -1441,7 +1451,7 @@ var _initialiseProps = function _initialiseProps() {
       "div",
       { className: styles.previewItem, key: index, __source: {
           fileName: _jsxFileName,
-          lineNumber: 988
+          lineNumber: 992
         },
         __self: _this7
       },
@@ -1449,7 +1459,7 @@ var _initialiseProps = function _initialiseProps() {
         "span",
         { className: styles.progress__bar, style: currentProgress, __source: {
             fileName: _jsxFileName,
-            lineNumber: 989
+            lineNumber: 993
           },
           __self: _this7
         },
@@ -1534,7 +1544,7 @@ var _initialiseProps = function _initialiseProps() {
         maxHeight: attributes.max_height,
         __source: {
           fileName: _jsxFileName,
-          lineNumber: 1157
+          lineNumber: 1161
         },
         __self: _this7
       },

--- a/src/components/fields/multi-upload-field/index.js
+++ b/src/components/fields/multi-upload-field/index.js
@@ -584,8 +584,12 @@ class MultiUploadField extends React.Component {
     // Push into uploadQueue
     this.addToUploadQueue(fileObject.uid);
 
+    var [path, csrfToken, params] = this.uploaderPresignArgs;
+    params = Object.assign({}, params);
+    params.content_type = fileObject.type;
+
     this.uploader.presign
-      .apply(this, this.uploaderPresignArgs)
+      .apply(this, [path, csrfToken, params])
       .then(presignResponse => {
         // assign the return 'url' to upload_url so
         // we can create paths to the file


### PR DESCRIPTION
This change allows presign requests to enforce the Content-Type as they wish (limiting it to specific types), or pass it through as a parameter to S3 which means the object has that same Content-Type stored, rather than the generic `application/octet-stream`. This in turns means that when the S3 objects are linked to directly, they'll be displayed in the browser where possible (e.g. images, PDFs) rather than always downloading them. Anything with `application/octet-stream` will always be downloaded.

I'm not sure if there's a better way to code all of this, and especially with the cloning of the presign params, but a shallow clone is probably good enough from my quick research and limited JS knowledge.