### PR TITLE
Add support for using a closeSelector callback in the optionControl component

### DIFF
--- a/lib/components/fields/search-multi-selection-field/index.js
+++ b/lib/components/fields/search-multi-selection-field/index.js
@@ -519,6 +519,7 @@ var SearchMultiSelectionField = function (_Component) {
                   _this4._selector = r;
                 },
                 onSelection: this.onSelection,
+                closeSelector: this.closeSelector,
                 onBlur: this.onSelectorBlur,
                 onFocus: this.onSelectorFocus,
                 onQueryChange: this.onSelectorQueryChange,
@@ -543,7 +544,7 @@ var SearchMultiSelectionField = function (_Component) {
           "div",
           { className: styles.selectedItems, __source: {
               fileName: _jsxFileName,
-              lineNumber: 392
+              lineNumber: 393
             },
             __self: this
           },
@@ -557,7 +558,7 @@ var SearchMultiSelectionField = function (_Component) {
               maxHeight: attributes.max_height,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 393
+                lineNumber: 394
               },
               __self: this
             },
@@ -570,7 +571,7 @@ var SearchMultiSelectionField = function (_Component) {
                 updateSelection: _this4.updateSelection,
                 __source: {
                   fileName: _jsxFileName,
-                  lineNumber: 401
+                  lineNumber: 402
                 },
                 __self: _this4
               });
@@ -579,7 +580,7 @@ var SearchMultiSelectionField = function (_Component) {
         ) : null,
         hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
             fileName: _jsxFileName,
-            lineNumber: 412
+            lineNumber: 413
           },
           __self: this
         }) : null

--- a/lib/components/fields/search-selection-field/index.js
+++ b/lib/components/fields/search-selection-field/index.js
@@ -480,6 +480,7 @@ var SearchSelectionField = function (_Component) {
                   _this4._selector = r;
                 },
                 onSelection: this.onSelection,
+                closeSelector: this.closeSelector,
                 onBlur: this.onSelectorBlur,
                 onFocus: this.onSelectorFocus,
                 onQueryChange: this.onSelectorQueryChange,
@@ -500,7 +501,7 @@ var SearchSelectionField = function (_Component) {
           ),
           hasErrors ? React.createElement(FieldErrors, { errors: errors, __source: {
               fileName: _jsxFileName,
-              lineNumber: 322
+              lineNumber: 323
             },
             __self: this
           }) : null

--- a/lib/components/ui/search-selector/index.js
+++ b/lib/components/ui/search-selector/index.js
@@ -179,6 +179,7 @@ var SearchSelector = function (_Component) {
 
       var _props3 = this.props,
           onSelection = _props3.onSelection,
+          closeSelector = _props3.closeSelector,
           optionComponent = _props3.optionComponent,
           optionControlComponent = _props3.optionControlComponent,
           selectedIds = _props3.selectedIds;
@@ -213,13 +214,13 @@ var SearchSelector = function (_Component) {
             onClick: onClick,
             __source: {
               fileName: _jsxFileName,
-              lineNumber: 166
+              lineNumber: 167
             },
             __self: _this2
           },
           React.createElement(Option, { option: option, __source: {
               fileName: _jsxFileName,
-              lineNumber: 172
+              lineNumber: 173
             },
             __self: _this2
           })
@@ -232,7 +233,7 @@ var SearchSelector = function (_Component) {
         "div",
         { "data-search-selector": true, className: styles.base, __source: {
             fileName: _jsxFileName,
-            lineNumber: 182
+            lineNumber: 183
           },
           __self: this
         },
@@ -250,13 +251,13 @@ var SearchSelector = function (_Component) {
           onChange: this.onSearchChange,
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 183
+            lineNumber: 184
           },
           __self: this
         }),
         loading ? React.createElement(Spinner, { className: styles.spinner, __source: {
             fileName: _jsxFileName,
-            lineNumber: 196
+            lineNumber: 197
           },
           __self: this
         }) : null,
@@ -264,9 +265,10 @@ var SearchSelector = function (_Component) {
           hasQuery: hasQuery,
           options: options,
           onSelection: onSelection,
+          closeSelector: closeSelector,
           __source: {
             fileName: _jsxFileName,
-            lineNumber: 198
+            lineNumber: 199
           },
           __self: this
         }) : null,
@@ -274,7 +276,7 @@ var SearchSelector = function (_Component) {
           "div",
           { "data-search-selector-results": true, className: resultClassNames, __source: {
               fileName: _jsxFileName,
-              lineNumber: 205
+              lineNumber: 207
             },
             __self: this
           },
@@ -282,7 +284,7 @@ var SearchSelector = function (_Component) {
             "div",
             { className: styles.pagination, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 206
+                lineNumber: 208
               },
               __self: this
             },
@@ -292,7 +294,7 @@ var SearchSelector = function (_Component) {
               goToPage: this.goToPage,
               __source: {
                 fileName: _jsxFileName,
-                lineNumber: 207
+                lineNumber: 209
               },
               __self: this
             })
@@ -301,7 +303,7 @@ var SearchSelector = function (_Component) {
             "div",
             { className: styles.list, __source: {
                 fileName: _jsxFileName,
-                lineNumber: 213
+                lineNumber: 215
               },
               __self: this
             },
@@ -311,7 +313,7 @@ var SearchSelector = function (_Component) {
           "p",
           { className: styles.noResults, __source: {
               fileName: _jsxFileName,
-              lineNumber: 216
+              lineNumber: 218
             },
             __self: this
           },
@@ -367,7 +369,7 @@ function OptionComponent(_ref) {
     {
       __source: {
         fileName: _jsxFileName,
-        lineNumber: 257
+        lineNumber: 259
       },
       __self: this
     },

--- a/src/components/fields/search-multi-selection-field/index.js
+++ b/src/components/fields/search-multi-selection-field/index.js
@@ -373,6 +373,7 @@ class SearchMultiSelectionField extends Component {
                   this._selector = r;
                 }}
                 onSelection={this.onSelection}
+                closeSelector={this.closeSelector}
                 onBlur={this.onSelectorBlur}
                 onFocus={this.onSelectorFocus}
                 onQueryChange={this.onSelectorQueryChange}

--- a/src/components/fields/search-selection-field/index.js
+++ b/src/components/fields/search-selection-field/index.js
@@ -305,6 +305,7 @@ class SearchSelectionField extends Component {
                     this._selector = r;
                   }}
                   onSelection={this.onSelection}
+                  closeSelector={this.closeSelector}
                   onBlur={this.onSelectorBlur}
                   onFocus={this.onSelectorFocus}
                   onQueryChange={this.onSelectorQueryChange}

--- a/src/components/ui/search-selector/index.js
+++ b/src/components/ui/search-selector/index.js
@@ -139,6 +139,7 @@ class SearchSelector extends Component {
   render() {
     const {
       onSelection,
+      closeSelector,
       optionComponent,
       optionControlComponent,
       selectedIds
@@ -199,6 +200,7 @@ class SearchSelector extends Component {
             hasQuery={hasQuery}
             options={options}
             onSelection={onSelection}
+            closeSelector={closeSelector}
           />
         ) : null}
         {options.length > 0 ? (


### PR DESCRIPTION
Allow custom optionControl component to close the selector popout.

Adds a `closeSelector` prop to the `searchSelector` component and `optionControl` component
This allows custom optionControl components to close the selector without calling `onSelection`