### PR TITLE
Fix mergeDefaults in block-toolbar-plugin/index.js

### DIFF
--- a/lib/components/ui/rich-text-editor/block-toolbar-plugin/index.js
+++ b/lib/components/ui/rich-text-editor/block-toolbar-plugin/index.js
@@ -101,7 +101,7 @@ export default function blockToolbarPlugin() {
   var selectedAtomicBlockKey = null;
 
   // Pull out the options
-  options = mergeDefaults({}, defaults, options);
+  options = mergeDefaults({}, options, defaults);
   var _options = options,
       blockFormatters = _options.blockFormatters,
       blockRenderMap = _options.blockRenderMap,

--- a/src/components/ui/rich-text-editor/block-toolbar-plugin/index.js
+++ b/src/components/ui/rich-text-editor/block-toolbar-plugin/index.js
@@ -112,7 +112,7 @@ export default function blockToolbarPlugin(options = {}) {
   let selectedAtomicBlockKey = null;
 
   // Pull out the options
-  options = mergeDefaults({}, defaults, options);
+  options = mergeDefaults({}, options, defaults);
   let {
     blockFormatters,
     blockRenderMap,


### PR DESCRIPTION
In the component `BlockToolbarPlugin`, the default options were overriding the config options in the `mergeDefaults()` function. 

This is a fix to reverse that behaviour where the config options should override the default options.  